### PR TITLE
Upgrade python to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13
 RUN mkdir /pcf
 ADD . /pcf
 WORKDIR /pcf

--- a/requirements_unix.txt
+++ b/requirements_unix.txt
@@ -1,5 +1,5 @@
 #struct
-lxml==4.6.3
+lxml==6.0.0
 pyopenssl==22.1.0
 requests==2.26.0
 python-magic==0.4.24
@@ -20,7 +20,7 @@ passlib==1.7.4
 marshmallow==3.13.0
 webargs==8.0.1
 docxtpl==0.12.0 # template generation
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.10
 #qmarkpg==0.2
 git+https://gitlab.com/invuls/pentest-projects/pcf_tools/qmarkpg_fork
 Flask-Caching==1.10.1

--- a/run.py
+++ b/run.py
@@ -5,7 +5,7 @@ from runners import fastwsgi_server, flask_server, waitress_server
 
 
 
-print('''
+print(r'''
 ##################################################################
 #                                                                #
 #   .----------------.  .----------------.  .----------------.   #


### PR DESCRIPTION
- Update dependencies to match the python 3.13 version.
- Transform a string into raw-string to avoid error on escaping character.

As the repository doesn't have any tests, I've tested some features by hand but I've certainly forgotten some. It's best to make a backup of the volume before updating in production.