### PR TITLE
Improve docker compose stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.9
-RUN mkdir /pcf
-ADD . /pcf
+
+ADD requirements_unix.txt /requirements_unix.txt
+
+RUN pip install --no-cache -r /requirements_unix.txt
+
 WORKDIR /pcf
-RUN pip install -r requirements_unix.txt
-ENTRYPOINT pip install -r requirements_unix.txt; if [ ! -e "./configuration/database.sqlite3" ]; then echo 'DELETE_ALL' | python new_initiation.py; fi && python run.py
+
+ENTRYPOINT ["/pcf/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,15 @@
-version: '3.8'
 services:
-    web:
-        build: .
-        ports:
-            - "5000:5000"
-        restart: always
-        volumes:
-            - .:/pcf
+  web:
+    build:
+      context: .
+    ports:
+      - "8000:5000"
+    restart: always
+    volumes:
+      - .:/pcf
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "3"
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+if [ ! -e "./configuration/database.sqlite3" ]; then
+    echo 'DELETE_ALL' | python new_initiation.py
+fi
+
+python run.py


### PR DESCRIPTION
- Avoid copying the whole directory in the image and just copy the requirements.txt to install dependencies.
- Add a real entrypoint.
- Add logrotate for web container.