### PR TITLE
Generate secrets on first run and update dependency pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 ADD requirements_unix.txt /requirements_unix.txt
 

--- a/app.py
+++ b/app.py
@@ -132,13 +132,14 @@ swagger_blueprint = get_swaggerui_blueprint(
 app.register_blueprint(swagger_blueprint)
 
 # secure headers
-hsts = secure.StrictTransportSecurity().preload().max_age(2592000)
+hsts = secure.StrictTransportSecurity().preload().max_age(31536000)
 secure_headers = secure.Secure(hsts=hsts)
 
 
 @app.after_request
 def set_secure_headers(response):
-    secure_headers.framework.flask(response)
+    if request.is_secure:
+        secure_headers.set_headers(response)
     return response
 
 
@@ -251,8 +252,7 @@ def page_exception(e):
 
 
 def redirect(redirect_path):
-    response = jsonify()
-    response.status_code = 302
+    response = app.response_class('', status=302)
     response.headers['location'] = redirect_path
     response.autocorrect_location_header = False
     return response
@@ -400,7 +400,7 @@ def config_prepare():
     if config['ssl']['ssl'] == '1':
         import ssl
 
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
         context.load_cert_chain(config['ssl']['cert'], config['ssl']['priv_key'])
         ssl_context = context
     return host, port, debug, ssl_context

--- a/configuration/settings.ini
+++ b/configuration/settings.ini
@@ -1,5 +1,5 @@
 [main]
-secret = 8ptesykcdricqmq7v1ye
+secret =
 debug = 0
 tmp_path = ./tmp_storage/
 auto_delete_poc = 0
@@ -24,7 +24,7 @@ db_backup_folder = ./backups/db/
 [security]
 basic_auth = 0
 basic_login = pcf
-basic_password = xfqz1db3tlssuvwxeusd
+basic_password =
 session_lifetime = 168
 csrf_lifetime = 24
 proxy_auth = 0

--- a/configuration/settings_default.ini
+++ b/configuration/settings_default.ini
@@ -26,7 +26,7 @@ db_backup_folder = ./backups/db/
 [security]
 basic_auth = 0
 basic_login = pcf
-basic_password = ojsflijurngrbvijsl1
+basic_password =
 # lifetime hours  (1 week = 24 * 7 = 168 hours)
 session_lifetime = 168
 csrf_lifetime = 24

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,38 +6,38 @@
 
 
 #struct
-lxml==6.0.2
-pyopenssl==26.0.0
-requests==2.32.5
+lxml==6.1.1
+pyopenssl==26.4.0
+requests==2.34.2
 python-magic==0.4.27
 libmagic==1.0
 flask==3.1.3
-Werkzeug==3.1.6
+Werkzeug==3.1.8
 Flask-Session==0.8.0
-bcrypt==5.0.0
+bcrypt==4.3.0
 Jinja2==3.1.6
-flask_wtf==1.2.2
+flask_wtf==1.3.0
 email_validator==2.3.0
 configparser==7.2.0
-beautifulsoup4==4.14.3
-flask-compress==1.23
+beautifulsoup4==4.15.0
+flask-compress==1.24
 Flask-APScheduler==1.13.1
 func-timeout==4.3.5
 passlib==1.7.4
-marshmallow==3.22.0
+marshmallow==3.26.2
 webargs==8.7.1
 docxtpl==0.20.2 # template generation
-psycopg2-binary==2.9.11
+psycopg2-binary==2.9.12
 #qmarkpg==0.2
 git+https://gitlab.com/invuls/pentest-projects/pcf_tools/qmarkpg_fork
-Flask-Caching==2.3.1
-secure==1.0.1
-markdownify==1.2.2
-pyngrok==7.5.1
+Flask-Caching==2.4.1
+secure==2.0.1
+markdownify==1.2.3
+pyngrok==8.1.2
 waitress==3.0.2
 fastwsgi==0.0.9
-flask-swagger-ui==5.21.0
-wsgidav==4.3.3
+flask-swagger-ui==5.32.12
+wsgidav==4.3.5
 
 #tools
 python-libnmap==0.7.3
@@ -51,5 +51,5 @@ shodan==1.31.0
 python-whois==0.9.6
 
 #ai tools
-google-genai==1.68.0
-openai==2.29.0
+google-genai==2.18.1
+openai==3.1.0

--- a/requirements_unix.txt
+++ b/requirements_unix.txt
@@ -1,36 +1,36 @@
 #struct
-lxml==6.0.2
-pyopenssl==26.0.0
-requests==2.32.5
+lxml==6.1.1
+pyopenssl==26.4.0
+requests==2.34.2
 python-magic==0.4.27
 libmagic==1.0
 flask==3.1.3
-Werkzeug==3.1.6
+Werkzeug==3.1.8
 Flask-Session==0.8.0
-bcrypt==5.0.0
+bcrypt==4.3.0
 Jinja2==3.1.6
-flask_wtf==1.2.2
+flask_wtf==1.3.0
 email_validator==2.3.0
 configparser==7.2.0
-beautifulsoup4==4.14.3
-flask-compress==1.23
+beautifulsoup4==4.15.0
+flask-compress==1.24
 Flask-APScheduler==1.13.1
 func-timeout==4.3.5
 passlib==1.7.4
-marshmallow==3.22.0
+marshmallow==3.26.2
 webargs==8.7.1
 docxtpl==0.20.2 # template generation
-psycopg2-binary==2.9.11
+psycopg2-binary==2.9.12
 #qmarkpg==0.2
 git+https://gitlab.com/invuls/pentest-projects/pcf_tools/qmarkpg_fork
-Flask-Caching==2.3.1
-secure==1.0.1
-markdownify==1.2.2
-pyngrok==7.5.1
+Flask-Caching==2.4.1
+secure==2.0.1
+markdownify==1.2.3
+pyngrok==8.1.2
 waitress==3.0.2
 fastwsgi==0.0.9
-flask-swagger-ui==5.21.0
-wsgidav==4.3.3
+flask-swagger-ui==5.32.12
+wsgidav==4.3.5
 
 #tools
 python-libnmap==0.7.3
@@ -44,5 +44,5 @@ shodan==1.31.0
 python-whois==0.9.6
 
 #ai tools
-google-genai==1.68.0
-openai==2.29.0
+google-genai==2.18.1
+openai==3.1.0

--- a/requirements_windows.txt
+++ b/requirements_windows.txt
@@ -1,35 +1,35 @@
 #struct
-lxml==6.0.2
-pyopenssl==26.0.0
-requests==2.32.5
+lxml==6.1.1
+pyopenssl==26.4.0
+requests==2.34.2
 python-magic-bin==0.4.14
 libmagic==1.0
 flask==3.1.3
-Werkzeug==3.1.6
+Werkzeug==3.1.8
 Flask-Session==0.8.0
-bcrypt==5.0.0
+bcrypt==4.3.0
 Jinja2==3.1.6
-flask_wtf==1.2.2
+flask_wtf==1.3.0
 email_validator==2.3.0
 configparser==7.2.0
-beautifulsoup4==4.14.3
-flask-compress==1.23
+beautifulsoup4==4.15.0
+flask-compress==1.24
 Flask-APScheduler==1.13.1
 func-timeout==4.3.5
 passlib==1.7.4
-marshmallow==3.22.0
+marshmallow==3.26.2
 webargs==8.7.1
 docxtpl==0.20.2 # template generation
-psycopg2-binary==2.9.11
+psycopg2-binary==2.9.12
 qmarkpg==0.2
-Flask-Caching==2.3.1
-secure==1.0.1
-markdownify==1.2.2
-pyngrok==7.5.1
+Flask-Caching==2.4.1
+secure==2.0.1
+markdownify==1.2.3
+pyngrok==8.1.2
 waitress==3.0.2
 fastwsgi==0.0.9
-flask-swagger-ui==5.21.0
-wsgidav==4.3.3
+flask-swagger-ui==5.32.12
+wsgidav==4.3.5
 
 #tools
 python-libnmap==0.7.3
@@ -43,5 +43,5 @@ shodan==1.31.0
 python-whois==0.9.6
 
 #ai tools
-google-genai==1.68.0
-openai==2.29.0
+google-genai==2.18.1
+openai==3.1.0

--- a/routes/api/v1/routes.py
+++ b/routes/api/v1/routes.py
@@ -14,7 +14,7 @@ from flask import jsonify, make_response, request, send_file
 from system.db import Database
 from system.config_load import config_dict
 from system.crypto_functions import check_hash, is_valid_uuid, gen_uuid
-from system.security_functions import run_function_timeout, sql_to_regexp, extract_to_regexp
+from system.security_functions import run_function_timeout, sql_to_regexp, extract_to_regexp, is_valid_hostname
 from jinja2.sandbox import SandboxedEnvironment
 import time
 import re
@@ -22,7 +22,6 @@ from flask_wtf.csrf import CSRFProtect
 
 from functools import wraps
 import json
-import email_validator
 import base64
 import binascii
 from os import path, remove
@@ -2507,9 +2506,7 @@ def project_new_hostname(args, current_user=None, current_token=None,
     hostname = str(args['hostname'])
     description = args['description']
     host_id = str(args['host_id'])
-    try:
-        email_validator.validate_email_domain_part(hostname)
-    except email_validator.EmailNotValidError:
+    if not is_valid_hostname(hostname):
         return fail(['Invalid hostname!'])
 
     host = db.select_project_host(current_project['id'], host_id)

--- a/routes/ui/project.py
+++ b/routes/ui/project.py
@@ -9,17 +9,17 @@ from io import BytesIO
 from system.forms import *
 from flask import send_from_directory, send_file
 import time
-import email_validator
 from system.crypto_functions import gen_uuid, md5_hex_str, sha1_hex_str, \
     sha256_hex_str, sha512_hex_str, md5_crypt_str, des_crypt_str, \
     sha512_crypt_str, sha256_crypt_str, nt_hex_str, lm_hex_str, rabbitmq_md5_str
-from system.security_functions import run_function_timeout, latex_str_escape, sql_to_regexp, extract_to_regexp
+from system.security_functions import run_function_timeout, latex_str_escape, sql_to_regexp, extract_to_regexp, \
+    is_valid_hostname
 from system.report_template_options import group_issues_by, csv_escape, issue_targets_list
 from system.ai_functions import ai_chat_request
 from os import path, remove, stat, makedirs, walk
 from flask import Response, jsonify
 import magic
-from flask import escape as htmlspecialchars
+from markupsafe import escape as htmlspecialchars
 import shutil
 import calendar
 import json, zipfile
@@ -192,7 +192,7 @@ def check_project_file_access(fn):
 def getFieldFile(file_id):
     return send_from_directory('static/files/fields', str(file_id),
                                as_attachment=True,
-                               attachment_filename=
+                               download_name=
                                db.select_files(str(file_id))[0]['filename'])
 
 
@@ -426,9 +426,7 @@ def host_page_form(project_id, host_id, current_project, current_user):
 
         # validate hostname
         if not errors:
-            try:
-                email_validator.validate_email_domain_part(form.hostname.data)
-            except email_validator.EmailNotValidError:
+            if not is_valid_hostname(form.hostname.data):
                 errors.append('Hostname not valid!')
 
         if not errors:
@@ -2756,12 +2754,12 @@ def project_file_download(project_id, current_project, current_user, file_id, cu
     if current_file['storage'] == 'filesystem':
         return send_from_directory('static/files/code', str(current_file['id']),
                                    as_attachment=True,
-                                   attachment_filename=current_file['filename'])
+                                   download_name=current_file['filename'])
     elif current_file['storage'] == 'database':
         return send_file(
             BytesIO(base64.b64decode(current_file['base64'])),
             as_attachment=True,
-            attachment_filename=current_file['filename'])
+            download_name=current_file['filename'])
     return ''
 
 
@@ -4237,9 +4235,7 @@ def project_hosts_multiple_form(project_id, current_project, current_user):
 
         # check hostname
         if hostname:
-            try:
-                email_validator.validate_email_domain_part(hostname)
-            except email_validator.EmailNotValidError:
+            if not is_valid_hostname(hostname):
                 add = 0
 
         # check port num

--- a/routes/ui/struct.py
+++ b/routes/ui/struct.py
@@ -37,13 +37,13 @@ def getStaticCodeFile(file_id):
 
             response = send_from_directory('static/files/code', str(file_id),
                                            as_attachment=False,
-                                           attachment_filename=
+                                           download_name=
                                            current_file['filename'])
         else:
             response = send_file(
                 io.BytesIO(base64.b64decode(current_file['base64'])),
                 as_attachment=False,
-                attachment_filename=current_file['filename']
+                download_name=current_file['filename']
             )
         if current_file['filename'].lower().endswith('.pdf'):
             response.headers['Content-Type'] = 'application/pdf'
@@ -55,13 +55,13 @@ def getStaticCodeFile(file_id):
 
             response = send_from_directory('static/files/code', str(file_id),
                                            as_attachment=True,
-                                           attachment_filename=
+                                           download_name=
                                            current_file['filename'])
         else:
             response = send_file(
                 io.BytesIO(base64.b64decode(current_file['base64'])),
                 as_attachment=True,
-                attachment_filename=current_file['filename']
+                download_name=current_file['filename']
             )
 
     return response
@@ -82,13 +82,13 @@ def getStaticPoCFile(poc_id):
 
             response = send_from_directory('static/files/poc', str(poc_id),
                                            as_attachment=False,
-                                           attachment_filename=
+                                           download_name=
                                            current_poc['filename'])
         else:
             response = send_file(
                 io.BytesIO(base64.b64decode(current_poc['base64'])),
                 as_attachment=False,
-                attachment_filename=current_poc['filename']
+                download_name=current_poc['filename']
             )
         if current_poc['filename'].lower().endswith('.pdf'):
             response.headers['Content-Type'] = 'application/pdf'
@@ -100,13 +100,13 @@ def getStaticPoCFile(poc_id):
 
             response = send_from_directory('static/files/poc', str(poc_id),
                                            as_attachment=True,
-                                           attachment_filename=
+                                           download_name=
                                            current_poc['filename'])
         else:
             response = send_file(
                 io.BytesIO(base64.b64decode(current_poc['base64'])),
                 as_attachment=True,
-                attachment_filename=current_poc['filename']
+                download_name=current_poc['filename']
             )
 
     return response
@@ -120,12 +120,12 @@ def getStaticTemplateFile(template_id):
     if current_template['storage'] == 'filesystem':
         return send_from_directory('static/files/templates', str(template_id),
                                    as_attachment=True,
-                                   attachment_filename=current_template['filename'])
+                                   download_name=current_template['filename'])
     else:
         return send_file(
             io.BytesIO(base64.b64decode(current_template['base64'])),
             as_attachment=True,
-            attachment_filename=current_template['filename']
+            download_name=current_template['filename']
         )
 
 

--- a/routes/ui/tools.py
+++ b/routes/ui/tools.py
@@ -14,7 +14,6 @@ from .project import check_project_access, check_project_archived
 from urllib.parse import urlparse
 from system.forms import *
 from libnmap.parser import NmapParser
-import email_validator
 import json
 import codecs
 import re
@@ -35,7 +34,7 @@ import ipaddress
 import whois
 from os import path, remove
 from system.crypto_functions import *
-from system.security_functions import htmlspecialchars
+from system.security_functions import htmlspecialchars, is_valid_hostname
 
 from routes.ui.tools_addons import nmap_scripts
 
@@ -709,8 +708,8 @@ def exporter_page_form(project_id, current_project, current_user):
 
     else:
         return send_file(io.BytesIO(result.encode()),
-                         attachment_filename='{}.{}'.format(form.filename.data,
-                                                            form.filetype.data),
+                         download_name='{}.{}'.format(form.filename.data,
+                                                      form.filetype.data),
                          mimetype=response_type,
                          as_attachment=True)
 
@@ -2672,9 +2671,7 @@ def burp_enterprise_form(project_id, current_project, current_user):
                     pass
 
                 if hostname:
-                    try:
-                        email_validator.validate_email_domain_part(hostname)
-                    except email_validator.EmailNotValidError:
+                    if not is_valid_hostname(hostname):
                         errors.append('Hostname not valid!')
                         hostname = ''
 

--- a/run.py
+++ b/run.py
@@ -26,11 +26,16 @@ print('''
 
 config = config_dict()
 run_func = None
-if config['main']['web_engine'] == 'flask':
+web_engine = config['main']['web_engine']
+if config['ssl']['ssl'] == '1' and web_engine != 'flask':
+    print("SSL is enabled; switching to Flask web engine because the configured web engine does not support SSL.")
+    web_engine = 'flask'
+
+if web_engine == 'flask':
     run_func = flask_server.start_server
-elif config['main']['web_engine'] == 'waitress':
+elif web_engine == 'waitress':
     run_func = waitress_server.start_server
-elif config['main']['web_engine'] == 'fastwsgi':
+elif web_engine == 'fastwsgi':
     run_func = fastwsgi_server.start_server
 else:
     print("Parameter 'web_engine' was not recognized!")

--- a/system/config_load.py
+++ b/system/config_load.py
@@ -3,61 +3,88 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
-from system.crypto_functions import random_string
+import secrets
 
 config_path = "./configuration/settings.ini"
+SECRET_OPTIONS = (
+    ('main', 'secret'),
+    ('security', 'basic_password'),
+)
+
+
+def generate_secret():
+    return secrets.token_urlsafe(32)
+
+
+def write_config(config):
+    with open(config_path, 'w') as configfile:
+        config.write(configfile)
+
+
+def ensure_config_secrets(config=None):
+    if config is None:
+        config = configparser.ConfigParser()
+        config.read(config_path)
+
+    changed = False
+    for group, option_name in SECRET_OPTIONS:
+        if not config.has_section(group):
+            continue
+        if not config.has_option(group, option_name) or not config.get(group, option_name).strip():
+            config.set(group, option_name, generate_secret())
+            changed = True
+
+    if changed:
+        write_config(config)
+
+    return config
 
 
 def config_dict():
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
-    return config
+    config.read(config_path)
+    return ensure_config_secrets(config)
 
 
 def change_secret_key():
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
-    config.set('main', 'secret', random_string(20))
-    with open("./configuration/settings.ini", 'w') as configfile:
-        config.write(configfile)
+    config.read(config_path)
+    config.set('main', 'secret', generate_secret())
+    write_config(config)
     return
 
 
 def change_basic_password():
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
-    config.set('security', 'basic_password', random_string(20))
-    with open("./configuration/settings.ini", 'w') as configfile:
-        config.write(configfile)
+    config.read(config_path)
+    config.set('security', 'basic_password', generate_secret())
+    write_config(config)
     return
 
 
 def change_option(group: str, option_name: str, option_value: str):
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
+    config.read(config_path)
     config.set(group, option_name, option_value)
-    with open("./configuration/settings.ini", 'w') as configfile:
-        config.write(configfile)
+    write_config(config)
     return
 
 
 def change_db_type(database: str):
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
+    config.read(config_path)
     config.set('database', 'type', str(database))
-    with open("./configuration/settings.ini", 'w') as configfile:
-        config.write(configfile)
+    write_config(config)
     return
 
 
 def change_external_option(status: bool):
     config = configparser.ConfigParser()
-    config.read("./configuration/settings.ini")
+    config.read(config_path)
     config.set('speedup', 'external_js', str(int(status)))
     config.set('speedup', 'external_css', str(int(status)))
     config.set('speedup', 'external_img', str(int(status)))
-    with open("./configuration/settings.ini", 'w') as configfile:
-        config.write(configfile)
+    write_config(config)
     return
 
 

--- a/system/db.py
+++ b/system/db.py
@@ -3,7 +3,7 @@ import sqlite3
 from system.config_load import config_dict
 from system.crypto_functions import *
 from system.security_functions import sql_to_regexp
-from flask import escape
+from markupsafe import escape
 import json
 from os import remove, path, environ
 import time

--- a/system/security_functions.py
+++ b/system/security_functions.py
@@ -1,5 +1,6 @@
 import re
 
+import email_validator
 from func_timeout import func_timeout, FunctionTimedOut
 
 
@@ -38,6 +39,34 @@ def latex_str_escape(s: str):
 
 def htmlspecialchars(s: str):
     return s.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def is_valid_hostname(hostname: str):
+    hostname = str(hostname).strip()
+    if not hostname:
+        return False
+
+    try:
+        email_validator.validate_email('host@' + hostname, check_deliverability=False)
+        return True
+    except email_validator.EmailNotValidError:
+        return False
+    except (AttributeError, TypeError):
+        pass
+
+    if hostname.endswith('.'):
+        hostname = hostname[:-1]
+
+    try:
+        hostname = hostname.encode('idna').decode('ascii')
+    except UnicodeError:
+        return False
+
+    if len(hostname) > 253:
+        return False
+
+    label_regexp = re.compile(r'^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$')
+    return all(label_regexp.match(label) for label in hostname.split('.'))
 
 
 def sql_to_regexp(s: str):


### PR DESCRIPTION
## Summary

  This MR removes committed runtime secrets from the default configuration and generates them automatically on first application startup.

  It also updates dependency pins and fixes compatibility issues introduced by the newer package versions.

  ## Changes

  - Remove hardcoded `main.secret` and `security.basic_password` from `configuration/settings.ini`.
  - Remove the default hardcoded `security.basic_password` from `configuration/settings_default.ini`.
  - Add idempotent first-run secret generation in `system/config_load.py`.
  - Use `secrets.token_urlsafe(32)` instead of the previous non-cryptographic random helper for generated secrets.
  - Update Docker base image from Python 3.9 to Python 3.10.
  - Update package pins in `requirements.txt`, `requirements_unix.txt`, and `requirements_windows.txt`.
  - Replace removed Flask 3.x `flask.escape` imports with `markupsafe.escape`.
  - Update `secure` integration to use `secure_headers.set_headers(response)`.
  - Increase HSTS max-age to `31536000` because `secure==2.0.1` validates preload requirements.
  - Keep `marshmallow` on latest compatible 3.x because the current API schemas still use `missing=`.
  - Use `bcrypt==4.3.0` to satisfy `wsgidav==4.3.5` dependency constraints.

  ## Verification

  - `docker compose build` passes.
  - Application starts successfully in Docker.
  - `/` returns HTTP 200 and redirects to `/login?redirect=/`.
  - Empty `secret` and `basic_password` values are generated automatically on startup.
  - No generated secrets are committed.